### PR TITLE
Proposal: Authenticated S3 Image Proxy

### DIFF
--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -106,7 +106,7 @@ async fn main() -> Result<()> {
         .route("/transaction/:id", get(transaction::get))
         .route("/weather", get(weather::get))
         .route("/photos", get(photo::get_all).post(photo::upload))
-        .route("/photos/:name/view", get(photo::view))
+        .route("/photos/:name", get(photo::view))
         .layer(ClerkLayer::new(
             MemoryCacheJwksProvider::new(clerk.clone()),
             None,

--- a/api/src/photo.rs
+++ b/api/src/photo.rs
@@ -36,7 +36,10 @@ pub async fn upload(
     mut multipart: Multipart,
 ) -> JsonRes<Photo> {
     let file = multipart.next_field().await?.unwrap();
-    let name = file.file_name().unwrap().to_owned();
+    let name = file
+        .file_name()
+        .map(|s| s.to_owned())
+        .unwrap_or_else(|| Uuid::new_v4().to_string());
     let content_type = file.content_type().unwrap();
     let user = get_user(&app.db, &jwt.sub).await?;
     if content_type.contains("image") {

--- a/web/app/components/SecureImage.tsx
+++ b/web/app/components/SecureImage.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import { useAuth } from "@clerk/react-router";
+
+type SecureImageProps = {
+  name: string;
+  className?: string;
+  alt?: string;
+};
+
+export default function SecureImage({
+  name,
+  className,
+  alt,
+}: SecureImageProps) {
+  const { getToken } = useAuth();
+  const [src, setSrc] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let objectUrl: string | null = null;
+    const fetchImage = async () => {
+      try {
+        const token = await getToken();
+        if (!token) return;
+
+        const response = await fetch(
+          `${import.meta.env.VITE_API_URL}/photos/${name}/view`,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+          },
+        );
+
+        if (!response.ok) throw new Error("Failed to load image");
+
+        const blob = await response.blob();
+        objectUrl = URL.createObjectURL(blob);
+        setSrc(objectUrl);
+      } catch (err) {
+        console.error(err);
+        setError(true);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchImage();
+
+    return () => {
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [name, getToken]);
+
+  if (loading)
+    return <div className={`bg-zinc-800 animate-pulse ${className}`} />;
+  if (error || !src)
+    return (
+      <div
+        className={`bg-zinc-800 flex items-center justify-center text-zinc-500 ${className}`}
+      >
+        Error
+      </div>
+    );
+
+  return <img src={src} className={className} alt={alt || name} />;
+}

--- a/web/app/components/SecureImage.tsx
+++ b/web/app/components/SecureImage.tsx
@@ -19,13 +19,14 @@ export default function SecureImage({
 
   useEffect(() => {
     let objectUrl: string | null = null;
+    let canceled = false;
     const fetchImage = async () => {
       try {
         const token = await getToken();
         if (!token) return;
 
         const response = await fetch(
-          `${import.meta.env.VITE_API_URL}/photos/${name}/view`,
+          `${import.meta.env.VITE_API_URL}/photos/${encodeURIComponent(name)}/view`,
           {
             headers: {
               Authorization: `Bearer ${token}`,
@@ -36,19 +37,23 @@ export default function SecureImage({
         if (!response.ok) throw new Error("Failed to load image");
 
         const blob = await response.blob();
+        if (canceled) return;
+        
         objectUrl = URL.createObjectURL(blob);
         setSrc(objectUrl);
       } catch (err) {
+        if (canceled) return;
         console.error(err);
         setError(true);
       } finally {
-        setLoading(false);
+        if (!canceled) setLoading(false);
       }
     };
 
     fetchImage();
 
     return () => {
+      canceled = true;
       if (objectUrl) URL.revokeObjectURL(objectUrl);
     };
   }, [name, getToken]);

--- a/web/app/components/SecureImage.tsx
+++ b/web/app/components/SecureImage.tsx
@@ -13,7 +13,7 @@ export default function SecureImage({
   alt,
 }: SecureImageProps) {
   const query = useGet<Blob>(
-    `/photos/${encodeURIComponent(name)}/view`,
+    `/photos/${encodeURIComponent(name)}`,
     true,
     "blob",
   );

--- a/web/app/pages/photos.tsx
+++ b/web/app/pages/photos.tsx
@@ -8,6 +8,7 @@ import { Form, useActionData, useLoaderData } from "react-router";
 import type { Route } from "./+types/photos";
 import toast from "react-hot-toast";
 import FileDrop from "~/components/FileDrop";
+import SecureImage from "~/components/SecureImage";
 
 export async function loader(args: Route.LoaderArgs) {
   const { getToken } = await getAuth(args);
@@ -60,10 +61,10 @@ export default function Photos() {
     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-1 items-stretch  py-8 px-4 relative">
       <FileDrop onDrop={handleDrop} uploading={uploading} style="ghost" />
       {photos.map((photo: Photo) => (
-        <img
+        <SecureImage
           key={photo.name}
+          name={photo.name}
           className="aspect-square object-cover min-h-full"
-          src={`${import.meta.env.VITE_R2_URL}/${photo.name}`}
         />
       ))}
       <Form method="post" encType="multipart/form-data" ref={formRef}>

--- a/web/app/utils/query.ts
+++ b/web/app/utils/query.ts
@@ -14,6 +14,7 @@ async function fetchInternal<T>(
   token: string,
   method: Method,
   body?: T,
+  responseType: "json" | "blob" = "json",
 ) {
   console.log("FECTHIG", path, method, body);
   const res = await fetch(path, {
@@ -25,6 +26,9 @@ async function fetchInternal<T>(
     body: body ? JSON.stringify(body) : undefined,
   });
   if (res.ok) {
+    if (responseType === "blob") {
+      return await res.blob();
+    }
     return await res.json();
   } else {
     throw Error(await res.text());
@@ -96,7 +100,11 @@ export function queryErrored<T>(query: QueryState<T>) {
   return query.status !== "fetched";
 }
 
-export function useGet<T>(url: string, enabled: boolean = true) {
+export function useGet<T>(
+  url: string,
+  enabled: boolean = true,
+  responseType: "json" | "blob" = "json",
+) {
   const { getToken } = useAuth();
   const [data, setData] = useState<QueryState<T>>({ status: "idle" });
   useEffect(() => {
@@ -122,13 +130,19 @@ export function useGet<T>(url: string, enabled: boolean = true) {
               status: "error",
             });
           };
-          fetchInternal(`${import.meta.env.VITE_API_URL}${url}`, token, "GET")
+          fetchInternal(
+            `${import.meta.env.VITE_API_URL}${url}`,
+            token,
+            "GET",
+            undefined,
+            responseType,
+          )
             .then(onSuccess)
             .catch(onError);
         }
       })();
     }
-  }, [url, enabled, getToken]);
+  }, [url, enabled, getToken, responseType]);
   return data;
 }
 


### PR DESCRIPTION
Goal: Prevent public access to images and restrict viewing to authorized users only.

1. Backend Implementation (api) We will shift from direct S3 downloads to an API proxy model.

- Modify api/src/photo.rs:
    - Uploads: Update the upload function to remove ObjectCannedAcl::PublicRead. New files will be private by default.
    - New Endpoint (view): Create a new handler pub async fn view(...).
        - Path: /photos/:name/view
        - Security: Validate the requesting user via ClerkJwt. - Authorization: Query the database (SELECT * FROM photo WHERE name =  AND author_id = ) to ensure the user owns the photo. - Retrieval: Use aws_sdk_s3 to get_object from the bucket. - Response: Stream the S3 byte stream directly to the client with the correct Content-Type and Cache-Control headers.
- Modify api/src/main.rs:
    - Register the new route: .route("/photos/:name/view", get(photo::view))

2. Frontend Implementation (web) Since standard <img> tags cannot send Authorization headers, we need a custom component to fetch images securely.

- Create web/app/components/SecureImage.tsx:
    - A wrapper component that accepts a photoName and className.
    - Uses fetch() with the Authorization: Bearer <token> header to call the new API endpoint.
    - Converts the response Blob into a local object URL (URL.createObjectURL).
    - Renders a standard <img> tag using the secure object URL.
- Update web/app/pages/photos.tsx:
    - Replace the direct usage of import.meta.env.VITE_R2_URL with the new <SecureImage /> component.

3. Migration (Self-Healing)
- Existing images on S3/R2 will remain "Public" until manually updated, but the frontend will stop using the public URLs immediately.
- Ideally, we would run a script to remove the Public ACL from existing objects, but strictly speaking, the API proxy will work regardless of the object's ACL status.

4. Trade-offs
- Pros: Strict security (database-backed ownership checks), no exposed public URLs.
- Cons: Higher bandwidth/CPU on the API server compared to direct S3 downloads.