### PR TITLE
feat(api): implement authenticated S3 image proxy

### DIFF
--- a/api/.sqlx/query-46d2922f730a8456f44d9e40104d873b98da25ec97f55be3e1131432d5c2044e.json
+++ b/api/.sqlx/query-46d2922f730a8456f44d9e40104d873b98da25ec97f55be3e1131432d5c2044e.json
@@ -1,0 +1,53 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select * from photo where name = $1 and author_id = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 2,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 3,
+        "name": "caption",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "author_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 5,
+        "name": "size_b",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "46d2922f730a8456f44d9e40104d873b98da25ec97f55be3e1131432d5c2044e"
+}

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -106,6 +106,7 @@ async fn main() -> Result<()> {
         .route("/transaction/:id", get(transaction::get))
         .route("/weather", get(weather::get))
         .route("/photos", get(photo::get_all).post(photo::upload))
+        .route("/photos/:name/view", get(photo::view))
         .layer(ClerkLayer::new(
             MemoryCacheJwksProvider::new(clerk.clone()),
             None,

--- a/api/src/photo.rs
+++ b/api/src/photo.rs
@@ -154,7 +154,7 @@ pub async fn view(
     }
     headers.insert(
         axum::http::header::CACHE_CONTROL,
-        "private, max-age=31536000".parse().unwrap(),
+        "private, max-age=2592000".parse().unwrap(),
     );
 
     Ok((headers, body))

--- a/api/src/photo.rs
+++ b/api/src/photo.rs
@@ -2,6 +2,7 @@ use axum::extract::Path;
 use axum::Extension;
 use axum::{
     extract::{Multipart, State},
+    response::IntoResponse,
     Json,
 };
 use chrono::{DateTime, Utc};
@@ -12,7 +13,10 @@ use ts_rs::TS;
 use uuid::Uuid;
 
 use crate::clerk::get_user;
-use crate::{error::JsonRes, AppState};
+use crate::{
+    error::{AppError, JsonRes},
+    AppState,
+};
 
 #[derive(TS)]
 #[ts(export)]
@@ -44,7 +48,6 @@ pub async fn upload(
             .put_object()
             .bucket("editor")
             .key(name.clone())
-            .acl(aws_sdk_s3::types::ObjectCannedAcl::PublicRead)
             .body(body)
             .send()
             .await?;
@@ -99,4 +102,60 @@ pub async fn get(Path(id): Path<String>, State(app): State<AppState>) -> JsonRes
         .fetch_one(&app.db)
         .await?;
     Ok(Json(document))
+}
+
+pub async fn view(
+    Path(name): Path<String>,
+    State(app): State<AppState>,
+    Extension(jwt): Extension<ClerkJwt>,
+) -> Result<impl IntoResponse, AppError> {
+    let user = get_user(&app.db, &jwt.sub).await?;
+
+    // Verify ownership
+    let _photo = query_as!(
+        Photo,
+        "select * from photo where name = $1 and author_id = $2",
+        name,
+        user.id
+    )
+    .fetch_one(&app.db)
+    .await?;
+
+    let object = app
+        .s3
+        .get_object()
+        .bucket("editor")
+        .key(name)
+        .send()
+        .await
+        .map_err(|e| anyhow::Error::new(e))?;
+
+    let bytes = object
+        .body
+        .collect()
+        .await
+        .map_err(|e| anyhow::Error::new(e))?
+        .into_bytes();
+
+    let body = axum::body::Body::from(bytes);
+
+    let mut headers = axum::http::HeaderMap::new();
+    if let Some(content_type) = object.content_type {
+        headers.insert(
+            axum::http::header::CONTENT_TYPE,
+            content_type.parse().unwrap(),
+        );
+    }
+    if let Some(content_length) = object.content_length {
+        headers.insert(
+            axum::http::header::CONTENT_LENGTH,
+            content_length.to_string().parse().unwrap(),
+        );
+    }
+    headers.insert(
+        axum::http::header::CACHE_CONTROL,
+        "private, max-age=31536000".parse().unwrap(),
+    );
+
+    Ok((headers, body))
 }


### PR DESCRIPTION
Remove public ACL from uploads and add /photos/:name/view endpoint.

Goal: Prevent public access to images and restrict viewing to authorized users only.

1. Backend Implementation (api) We will shift from direct S3 downloads to an API proxy model.

- Modify api/src/photo.rs:
    - Uploads: Update the upload function to remove ObjectCannedAcl::PublicRead. New files will be private by default.
    - New Endpoint (view): Create a new handler pub async fn view(...).
        - Path: /photos/:name/view
        - Security: Validate the requesting user via ClerkJwt. - Authorization: Query the database (SELECT * FROM photo WHERE name =  AND author_id = ) to ensure the user owns the photo. - Retrieval: Use aws_sdk_s3 to get_object from the bucket. - Response: Stream the S3 byte stream directly to the client with the correct Content-Type and Cache-Control headers.
- Modify api/src/main.rs:
    - Register the new route: .route("/photos/:name/view", get(photo::view))

2. Frontend Implementation (web) Since standard <img> tags cannot send Authorization headers, we need a custom component to fetch images securely.

- Create web/app/components/SecureImage.tsx:
    - A wrapper component that accepts a photoName and className.
    - Uses fetch() with the Authorization: Bearer <token> header to call the new API endpoint.
    - Converts the response Blob into a local object URL (URL.createObjectURL).
    - Renders a standard <img> tag using the secure object URL.
- Update web/app/pages/photos.tsx:
    - Replace the direct usage of import.meta.env.VITE_R2_URL with the new <SecureImage /> component.

3. Migration (Self-Healing)
- Existing images on S3/R2 will remain "Public" until manually updated, but the frontend will stop using the public URLs immediately.
- Ideally, we would run a script to remove the Public ACL from existing objects, but strictly speaking, the API proxy will work regardless of the object's ACL status.

4. Trade-offs
- Pros: Strict security (database-backed ownership checks), no exposed public URLs.
- Cons: Higher bandwidth/CPU on the API server compared to direct S3 downloads.